### PR TITLE
Fix occasionally race condition during link assignment

### DIFF
--- a/src/components/admin.tsx
+++ b/src/components/admin.tsx
@@ -439,7 +439,7 @@ function Admin({ user }: adminProps) {
     link.postalCode = postalcode as string;
     link.linkType = linktype;
     return pollingFunction(async () => {
-      set(ref(database, `links/${addressLinkId}`), link);
+      await set(ref(database, `links/${addressLinkId}`), link);
       await triggerPostalCodeListeners(link.postalCode);
     });
   };


### PR DESCRIPTION
If there is a `async` indicator for the function, then we will need to `await` any functions that needs to be completed before moving on (even if the upper function is already awaiting). If not, the execution flow will not pause for those functions to complete and we may hit a race condition like that of brother Cecil. That also explains why there is no loading spinner after a successful share.   @bumblebeelabs 

