### PR TITLE
feat: congregation level slip expiry hours setting

### DIFF
--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -129,6 +129,12 @@ const checkTraceLangStatus = async (code: string) => {
   );
 };
 
+const checkCongregationExpireHours = async (code: string) => {
+  return await pollingFunction(() =>
+    get(child(ref(database), `congregations/${code}/expiryHours`))
+  );
+};
+
 const processAddressData = async (postal: String, data: any) => {
   const dataList = [];
   for (const floor in data) {
@@ -230,6 +236,7 @@ export {
   pollingFunction,
   checkTraceLangStatus,
   checkTraceRaceStatus,
+  checkCongregationExpireHours,
   processLinkCounts,
   triggerPostalCodeListeners,
   processAddressData


### PR DESCRIPTION
@Fauxicing I have configured the slip to expire in 3 hours time for CCK. WN is as per normal.
Please test and check if assignment and view timings are correct.